### PR TITLE
chore: add stale PR cleanup workflow via centralized pr-manager

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,8 @@
+name: PR Manager
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+jobs:
+  pr-manager:
+    uses: razorpay/actions/.github/workflows/pr-manager.yaml@main


### PR DESCRIPTION
Adds centralized PR Manager workflow that delegates stale PR cleanup to `razorpay/actions/.github/workflows/pr-manager.yaml`.